### PR TITLE
OFF-876 [Prebid Adapter] Check userKey for empty string

### DIFF
--- a/modules/flippBidAdapter.js
+++ b/modules/flippBidAdapter.js
@@ -25,13 +25,16 @@ export function getUserKey(options = {}) {
   }
 
   // If the partner provides the user key use it, otherwise fallback to cookies
-  if (options.userKey && isValidUserKey(options.userKey)) {
-    userKey = options.userKey;
-    return options.userKey;
+  if ('userKey' in options && options.userKey) {
+    if (isValidUserKey(options.userKey)) {
+      userKey = options.userKey;
+      return options.userKey;
+    }
   }
+
   // Grab from Cookie
-  const foundUserKey = storage.cookiesAreEnabled() && storage.getCookie(FLIPP_USER_KEY);
-  if (foundUserKey) {
+  const foundUserKey = storage.cookiesAreEnabled(null) && storage.getCookie(FLIPP_USER_KEY, null);
+  if (foundUserKey && isValidUserKey(foundUserKey)) {
     return foundUserKey;
   }
 
@@ -47,7 +50,7 @@ export function getUserKey(options = {}) {
 }
 
 function isValidUserKey(userKey) {
-  return !userKey.startsWith('#');
+  return typeof userKey === 'string' && !userKey.startsWith('#') && userKey.length > 0;
 }
 
 const generateUUID = () => {

--- a/modules/flippBidAdapter.md
+++ b/modules/flippBidAdapter.md
@@ -32,9 +32,10 @@ var adUnits = [
                     publisherNameIdentifier: 'wishabi-test-publisher', // Required
                     siteId: 1192075, // Required
                     zoneIds: [260678], // Optional
-                    userKey: "", // Optional
+                    userKey: `4188d8a3-22d1-49cb-8624-8838a22562bd`, // Optional
                     options: {
-                        startCompact: true // Optional, default to true
+                        startCompact: true, // Optional. Height of the experience will be reduced. Default to true
+                        dwellExpand: true // Optional. Auto expand the experience after a certain time passes. Default to true
                     }
                 }
             }

--- a/modules/flippBidAdapter.md
+++ b/modules/flippBidAdapter.md
@@ -32,7 +32,7 @@ var adUnits = [
                     publisherNameIdentifier: 'wishabi-test-publisher', // Required
                     siteId: 1192075, // Required
                     zoneIds: [260678], // Optional
-                    userKey: `4188d8a3-22d1-49cb-8624-8838a22562bd`, // Optional
+                    userKey: `4188d8a3-22d1-49cb-8624-8838a22562bd`, // Optional, in UUID format
                     options: {
                         startCompact: true, // Optional. Height of the experience will be reduced. Default to true
                         dwellExpand: true // Optional. Auto expand the experience after a certain time passes. Default to true


### PR DESCRIPTION
Add more checks to userKey
Update documentation

Tested that in case of missing or empty string userKey property, an randomly generated key would be sent
![image](https://github.com/wishabi/Prebid.js/assets/15764807/e4d518ca-2442-4b77-a8af-48ee282ac6d5)
![image](https://github.com/wishabi/Prebid.js/assets/15764807/59eb452f-4ffa-4eb9-89cb-7eb21b1f0905)
With `storageAllowed`, the adapter was able to get/set userKey from cookies
![image](https://github.com/wishabi/Prebid.js/assets/15764807/87552bd2-ac7f-4f43-b737-526582d889ac)
