### PR TITLE
OFF-1455 [Prebid.js] height should use the compactHeight and standardHeight fields in decisions response

### DIFF
--- a/modules/flippBidAdapter.js
+++ b/modules/flippBidAdapter.js
@@ -15,6 +15,7 @@ const DEFAULT_CREATIVE_TYPE = 'NativeX';
 const VALID_CREATIVE_TYPES = ['DTX', 'NativeX'];
 const FLIPP_USER_KEY = 'flipp-uid';
 const COMPACT_DEFAULT_HEIGHT = 600;
+const STANDARD_DEFAULT_HEIGHT = 1800;
 
 let userKey = null;
 export const storage = getStorageManager({bidderCode: BIDDER_CODE});
@@ -156,7 +157,10 @@ export const spec = {
     if (!isEmpty(res) && !isEmpty(res.decisions) && !isEmpty(res.decisions.inline)) {
       return res.decisions.inline.map(decision => {
         const placement = placements.find(p => p.prebid.requestId === decision.prebid?.requestId);
-        const height = placement.options?.startCompact ? COMPACT_DEFAULT_HEIGHT : decision.height;
+        const customData = decision.contents[0]?.data?.customData;
+        const height = placement.options?.startCompact
+          ? customData?.compactHeight ?? COMPACT_DEFAULT_HEIGHT
+          : customData?.standardHeight ?? STANDARD_DEFAULT_HEIGHT;
         return {
           bidderCode: BIDDER_CODE,
           requestId: decision.prebid?.requestId,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
Fix the issue where the height of our creative was using the value of decision.height

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
